### PR TITLE
feat(Melt UI Modal): Add Modal using MeltUI Dialog

### DIFF
--- a/src/elements/H3.svelte
+++ b/src/elements/H3.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { FontSize, Accent } from '$elements/element-types'
+
+	export let style = ''
+	export let size: FontSize = 'large'
+	export let accent: Accent = 'title'
+</script>
+
+<h3
+	class={`${size}_font ${accent}_color ${$$props.class ?? ''}`}
+	{style}
+	data-testid={$$props['data-testid']}
+>
+	<slot />
+</h3>

--- a/src/elements/element-types.ts
+++ b/src/elements/element-types.ts
@@ -27,3 +27,4 @@ export type IconName =
 	| 'light_mode'
 	| 'visibility' // eye
 	| 'visibility_off'
+	| 'info'

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ declare const __VERSION__: string
 declare const Button: (typeof import('./elements/Button.svelte'))['default']
 declare const IconButton: (typeof import('./elements/IconButton.svelte'))['default']
 declare const P: (typeof import('./elements/P.svelte'))['default']
+declare const H3: (typeof import('./elements/H3.svelte'))['default']
 declare const Icon: (typeof import('./elements/Icon.svelte'))['default']
 
 declare const onMount: (typeof import('svelte'))['onMount']

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { createDialog, melt } from '@melt-ui/svelte'
+	const {
+		elements: { trigger, portalled, overlay, content, title, description, close },
+		states: { open }
+	} = createDialog()
+</script>
+
+<button use:melt={$trigger}><slot name="trigger"></slot></button>
+
+{#if $open}
+	<div class="modal_wrapper" use:melt={$portalled}>
+		<div class="modal_overlay" use:melt={$overlay}></div>
+		<div class="modal_content_wrapper" use:melt={$content}>
+			<div class="modal_header">
+				<h2 use:melt={$title}><slot name="title">Dialog Title</slot></h2>
+				<button class="close_button" use:melt={$close}>
+					<Icon name="close" />
+				</button>
+			</div>
+			<div class="modal_body">
+				<slot />
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	.modal_wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: fixed;
+		inset: 0;
+		z-index: var(--modal_level);
+	}
+
+	.modal_overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: rgba(0, 0, 0, 0.5);
+		z-index: -1;
+	}
+
+	.modal_content_wrapper {
+		background-color: var(--card_color);
+		border-radius: var(--border_radius);
+		box-shadow: var(--shadow);
+		max-width: 42rem;
+		width: 100%;
+		margin: var(--gap_small);
+		overflow: auto;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.modal_header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--gap) var(--gap_small);
+		border-bottom: var(--line);
+		background-color: var(--bg_color);
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	.modal_body {
+		padding: var(--gap_small);
+	}
+
+	.close_button {
+		background: none;
+		border: none;
+		color: var(--error);
+		cursor: pointer;
+		font-size: 1.2rem;
+	}
+</style>

--- a/src/lib/components/StepEmbed.svelte
+++ b/src/lib/components/StepEmbed.svelte
@@ -13,6 +13,8 @@
 	import IconButton from '$elements/IconButton.svelte'
 	import { fade } from 'svelte/transition'
 	import { addToast } from '$lib/components/Toaster.svelte'
+	import Modal from './Modal.svelte'
+	import Divider from '$elements/Divider.svelte'
 
 	const demoFile = './demo.stp'
 
@@ -330,6 +332,41 @@
 		</div>
 	{:else}
 		<div class="control_buttons" transition:fade={{ duration: 300 }}>
+			<Modal>
+				<span slot="trigger">
+					<IconButton name="info" tooltipText="Info" />
+				</span>
+				<div slot="title">Instructions</div>
+				<div>
+					<H3 accent="primary">Loading a STEP File</H3>
+					<p>
+						Click "Import STEP" to upload your file (.stp or .step). Click "Load Demo" to load a
+						demo model.
+					</p>
+					<H3 accent="primary">Viewing and Navigating</H3>
+					<p>
+						Zoom: Use mouse wheel.<br />Rotate: Hold left mouse button and move.<br />Move: Hold
+						right mouse button and move.
+					</p>
+					<H3 accent="primary">Additional Controls</H3>
+					<p>
+						Reset Camera<br />Toggle Info<br />Toggle Mode
+						<br />Remove Model
+					</p>
+					<H3 accent="primary">Model Information (currently in mm² only)</H3>
+					<p>
+						Surface Area<br />Part Volume<br />Bounding Box
+					</p>
+					<H3 accent="primary">Notes</H3>
+					<p>
+						Supports .stp and .step formats.<br />Toggle info and mode for better visibility.<br
+						/>Keep file size reasonable for performance.
+					</p>
+				</div>
+			</Modal>
+
+			<Divider />
+
 			<IconButton
 				name="restart_alt"
 				on:click={resetCamera}

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -56,7 +56,7 @@
 		gap: 0.5rem;
 	}
 
-	@media (min-width: 768px) {
+	@media (min-width: 900px) {
 		.toast-container {
 			bottom: 0;
 			top: auto;


### PR DESCRIPTION
Add dialog component from Melt UI and other elements. Add a button to show instructions.

<img width="1424" alt="Screenshot 2024-06-16 at 10 35 35 PM" src="https://github.com/ubemacapuno/svelte-step-bro/assets/97559559/60c4fbcb-1438-472c-9306-c1ff63de8c07">
